### PR TITLE
Add (failing) test case for unroundable time stamp

### DIFF
--- a/tests/data.py
+++ b/tests/data.py
@@ -149,3 +149,16 @@ D 23:16:30.6284990 GameState.DebugPrintOptions() -   option 15 type=POWER mainEn
 D 23:16:30.6293790 GameState.DebugPrintOptions() -   option 16 type=POWER mainEntity=[name=Chillwind Yeti id=37 zone=PLAY zonePos=1 cardId=CS2_182 player=2] error=REQ_YOUR_TURN errorParam=
 D 23:16:30.6303440 GameState.DebugPrintOptions() -   option 17 type=POWER mainEntity=[name=UNKNOWN ENTITY [cardType=INVALID] id=44 zone=HAND zonePos=1 cardId= player=2] error=REQ_YOUR_TURN errorParam=
 """.strip()
+
+UNROUNDABLE_TIMESTAMP = """
+D 14:43:59.9999997 GameState.DebugPrintPower() - BLOCK_START BlockType=PLAY Entity=[entityName=Bonemare id=25 zone=HAND zonePos=2 cardId=ICC_705 player=1] EffectCardId= EffectIndex=0 Target=[entityName=Spellbreaker id=32 zone=PLAY zonePos=1 cardId=EX1_048 player=1] SubOption=-1
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=Doomflow tag=RESOURCES_USED value=8
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=Doomflow tag=NUM_RESOURCES_SPENT_THIS_GAME value=46
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=Doomflow tag=NUM_CARDS_PLAYED_THIS_TURN value=2
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=Doomflow tag=NUM_MINIONS_PLAYED_THIS_TURN value=2
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=[entityName=Soulfire id=4 zone=HAND zonePos=6 cardId=EX1_308 player=1] tag=ZONE_POSITION value=5
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=[entityName=Spellbreaker id=33 zone=HAND zonePos=5 cardId=EX1_048 player=1] tag=ZONE_POSITION value=4
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=[entityName=Flame Imp id=28 zone=HAND zonePos=4 cardId=EX1_319 player=1] tag=ZONE_POSITION value=3
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=[entityName=Malchezaar's Imp id=18 zone=HAND zonePos=3 cardId=KAR_089 player=1] tag=ZONE_POSITION value=2
+D 14:43:59.9999997 GameState.DebugPrintPower() -     TAG_CHANGE Entity=[entityName=Bonemare id=25 zone=HAND zonePos=2 cardId=ICC_705 player=1] tag=ZONE_POSITION value=0
+""".strip()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,8 +14,8 @@ from hslog.export import FriendlyPlayerExporter
 from hslog.parser import parse_entity_id, parse_initial_tag
 
 from .data import (
-	CONTROLLER_CHANGE, EMPTY_GAME, FULL_ENTITY,
-	INITIAL_GAME, INVALID_GAME, OPTIONS_WITH_ERRORS
+	CONTROLLER_CHANGE, EMPTY_GAME, FULL_ENTITY, INITIAL_GAME,
+	INVALID_GAME, OPTIONS_WITH_ERRORS, UNROUNDABLE_TIMESTAMP
 )
 
 
@@ -170,6 +170,18 @@ def test_timestamp_parsing():
 	assert ts.second == 14
 	assert ts.tzinfo
 	assert ts.utcoffset() == timedelta(hours=2)
+
+
+def test_unroundable_timestamp():
+	parser = LogParser()
+	parser.read(StringIO(INITIAL_GAME))
+	parser.read(StringIO(UNROUNDABLE_TIMESTAMP))
+	parser.flush()
+
+	# Should probably assert something like:
+	#   assert parser.games[0].packets[0].ts == time(14, 43, 59, 999999)
+	# or
+	#   assert parser.games[0].packets[0].ts == time(14, 44, 0, 0)
 
 
 def test_info_outside_of_metadata():


### PR DESCRIPTION
This PR adds a failing test case for the following issue:

These log lines will fail to parse due to their timestamp:

https://github.com/HearthSim/python-hslog/blob/71c29cadeeb530e4a2d346b60686032513618e91/tests/data.py#L154-L163

The following error occurs:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
hslog/parser.py:628: in read
    self.read_line(line)
hslog/parser.py:651: in read_line
    ts = self.parse_timestamp(ts, method)
hslog/parser.py:597: in parse_timestamp
    ret = parse_time(ts)
.tox/py36/lib/python3.6/site-packages/aniso8601/time.py:107: in parse_time
    return _parse_time_naive(timestr)
.tox/py36/lib/python3.6/site-packages/aniso8601/time.py:136: in _parse_time_naive
    return _RESOLUTION_MAP[get_time_resolution(timestr)](timestr)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

timestr = '14:43:59.9999997'

    def _parse_second_time(timestr):
        #Format must be hhmmss, hhmmss., hh:mm:ss or hh:mm:ss.
        if timestr.count(':') == 2:
            #hh:mm:ss or hh:mm:ss.
            timestrarray = timestr.split(':')
    
            isohour = int(timestrarray[0])
            isominute = int(timestrarray[1])
    
            #Since the time constructor doesn't handle fractional seconds, we put
            #the seconds in to a timedelta, and add it to the time before returning
            secondsdelta = datetime.timedelta(seconds=float(timestrarray[2]))
        else:
            #hhmmss or hhmmss.
            isohour = int(timestr[0:2])
            isominute = int(timestr[2:4])
    
            #Since the time constructor doesn't handle fractional seconds, we put
            #the seconds in to a timedelta, and add it to the time before returning
            secondsdelta = datetime.timedelta(seconds=float(timestr[4:]))
    
        if secondsdelta.seconds >= 60:
            #https://bitbucket.org/nielsenb/aniso8601/issues/13/parsing-of-leap-second-gives-wildly
>           raise ValueError('Seconds must be less than 60.')
E           ValueError: Seconds must be less than 60.

isohour    = 14
isominute  = 43
secondsdelta = datetime.timedelta(0, 60)
timestr    = '14:43:59.9999997'
timestrarray = ['14', '43', '59.9999997']
```

The issue is pretty evident from the first `if`-branch in `_parse_second_time`: seconds are converted to a timedelta, and timedelta rounds `59.9999997` to 60. We then fail the `secondsdelta.seconds >= 60` check and throw the error.

This should probably be handled because it's breaking some replays.