### PR TITLE
Allow FULL_ENTITY inside DEATHS blocks to preserve DEATHS in BGS filter

### DIFF
--- a/hslog/filter.py
+++ b/hslog/filter.py
@@ -88,8 +88,11 @@ class BattlegroundsLogFilter(Iterable):
         (such as those for DEATHRATTLEs) are discarded; ATTACK blocks for heroes will cause
         the next 4 blocks to be preserved, consistent with the logic for refreshing the
         `battlegrounds_combat_snapshot` materialized view
-    - DEATHS blocks with no subblocks and no TAG_CHANGES targeting PLAYER_TECH_LEVEL are
-        discarded
+    - DEATHS blocks with:
+            - no subblocks
+            - no TAG_CHANGES targeting PLAYER_TECH_LEVEL
+            - no FULL_ENTITY messages
+        ...are discarded
     - All options messages (from DebugPrintOptions) are discarded
     - Blacklisted and unknown tags for FULL_ENTITY and SHOW_ENTITY messages are discarded
     - TAG_CHANGES containing blacklisted and unknown tags are discarded
@@ -310,6 +313,8 @@ class BattlegroundsLogFilter(Iterable):
 
         if self._buffering_entity():
             self._end_buffer()
+        elif self._current_buffer and self._current_buffer.subtype == "DEATHS":
+            self._current_buffer.should_skip = False
 
         self._start_new_buffer(opcode, "")
         self._emit_line(line)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -190,3 +190,26 @@ class TestBattlegroundsLogFilter:
         )
 
         assert list(BattlegroundsLogFilter(minion_death)) == []
+
+    def test_preserve_deaths_162867(self):
+        full_entity = (
+            "D 04:48:45.7822406 GameState.DebugPrintPower() -     BLOCK_START "
+            "BlockType=DEATHS Entity=GameEntity "
+            "EffectCardId=System.Collections.Generic.List`1[System.String] EffectIndex=0 "
+            "Target=0 SubOption=-1 \n"
+
+            "D 04:48:45.7822406 GameState.DebugPrintPower() -         FULL_ENTITY - "
+            "Creating ID=7724 CardID=BG24_005\n"
+
+            "D 04:48:45.7822406 GameState.DebugPrintPower() -             tag=CONTROLLER "
+            "value=4\n"
+
+            "D 04:48:45.7822406 GameState.DebugPrintPower() -             tag=CARDTYPE "
+            "value=MINION\n"
+
+            "D 04:48:45.7822406 GameState.DebugPrintPower() - BLOCK_END\n"
+        )
+
+        assert list(BattlegroundsLogFilter(StringIO(full_entity))) == [
+            line + "\n" for line in full_entity.split("\n") if line
+        ]


### PR DESCRIPTION
Hearthstone 25.2 Battlegrounds includes an exotic range of Reborn minions, some of whom register their FULL_ENTITY messages inside a DEATHS block. This change adds to the conditions that can keep a DEATHS block from being discarded by the Battlegrounds log filter