### PR TITLE
Restore TAG_CHANGES in BOARD_VISUAL_STATE=2 TRIGGER blocks

### DIFF
--- a/hslog/filter.py
+++ b/hslog/filter.py
@@ -100,8 +100,6 @@ class BattlegroundsLogFilter(Iterable):
     - All options messages (from DebugPrintOptions) are discarded
     - Blacklisted and unknown tags for FULL_ENTITY and SHOW_ENTITY messages are discarded
     - TAG_CHANGES containing blacklisted and unknown tags are discarded
-    - All TAG_CHANGES that are part of a TRIGGER block that include a BOARD_VISUAL_STATE=2
-        tag change are discarded
     - All TAG_CHANGES that precede a BOARD_VISUAL_STATE=1 tag change in a TRIGGER block are
         discarded
     """
@@ -391,9 +389,6 @@ class BattlegroundsLogFilter(Iterable):
                             buf.buffer.append(buffered_item)
                             buf.should_skip = True
                             self._current_buffer.buffer[i] = buf
-
-                    if value == "2":
-                        setattr(self._current_buffer, "skip_tag_changes", True)
 
                     return
 


### PR DESCRIPTION
There's some logic in the filter to strip out tag changes that share a TRIGGER block with a tag change that sets BOARD_VISUAL_STATE to 2. We believe that for some time now, BOARD_VISUAL_STATEs 1 or 2 are related to shop manipulation code and not part of what we want to capture in combat.

However! In a recent BGS log, there are tag changes that seem to represent enchantments (i.e., ATK and HEALTH buffs) being applied to entities in a BOARD_VISUAL_STATE=2 block; whereas in older BGS logs, that happens in a separate block.

This change removes the logic that was stripping all BOARD_VISUAL_STATE=2 block tag changes.